### PR TITLE
feat: Add refresh token API (POST /api/auth/refresh)

### DIFF
--- a/spring/src/main/java/com/roadit/roaditbackend/controller/AuthController.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/controller/AuthController.java
@@ -43,4 +43,10 @@ public class AuthController {
         LoginResponse response = authService.googleLogin(request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<LoginResponse>> refreshToken(@RequestBody @Valid RefreshTokenRequest request) {
+        LoginResponse response = authService.refreshToken(request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
 }

--- a/spring/src/main/java/com/roadit/roaditbackend/dto/RefreshTokenRequest.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/dto/RefreshTokenRequest.java
@@ -1,0 +1,12 @@
+package com.roadit.roaditbackend.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RefreshTokenRequest {
+    private String refreshToken;
+}


### PR DESCRIPTION
- Implemented `refreshToken()` logic in AuthService
- Created POST /api/auth/refresh endpoint
- Returns new accessToken and refreshToken if the existing refreshToken is valid
- Added validation for expired or tampered refresh tokens