### PR TITLE
SecurityConfig.java 최신방식 refactoring

### DIFF
--- a/spring/src/main/java/com/roadit/roaditbackend/config/SecurityConfig.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/config/SecurityConfig.java
@@ -24,13 +24,17 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf().disable()
-                .authorizeHttpRequests()
-                .requestMatchers("/api/**").permitAll()
-                .anyRequest().authenticated()
-                .and()
-                .formLogin().disable()
-                .oauth2Login();
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(
+                                "/api/**",
+                                "/api/login/**",
+                                "/api/auth/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin(form -> form.disable())
+                .oauth2Login(Customizer.withDefaults());
 
         return http.build();
     }


### PR DESCRIPTION
feat: Spring Security 6.1+ 호환을 위한 SecurityConfig 리팩토링

- deprecated 된 메서드들 (csrf(), authorizeHttpRequests(), and(), formLogin(), oauth2Login()) 제거
- 람다 기반 방식으로 Security DSL 구조 개선
- 향후 버전 대응성을 높이기 위한 조치

참고: https://docs.spring.io/spring-security/reference/migration/servlet/config.html