### PR TITLE
 change logoout logic (delete->true/false)

### DIFF
--- a/spring/src/main/java/com/roadit/roaditbackend/entity/UserRefreshTokens.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/entity/UserRefreshTokens.java
@@ -29,11 +29,14 @@ public class UserRefreshTokens {
 
     private LocalDateTime expiresAt;
 
+    private boolean active;
+
     @PrePersist
     public void prePersist() {
 
         this.createdAt = LocalDateTime.now();
         this.expiresAt = createdAt.plusDays(7);
+        this.active = true;
     }
 
 }


### PR DESCRIPTION
🔧 기존 방식
	•	Refresh Token을 DB에서 삭제
	•	로그아웃 시 refreshTokenRepository.delete(...)

✅ 새로운 방식 (현재 적용된 로직)
	1.	userId와 deviceInfo를 요청으로 전달
	2.	user_refresh_tokens 테이블에서 해당 유저의 토큰 조회
	3.	조회된 토큰의 active 필드를 **false**로 변경 → 즉시 DB 반영
	4.	이후 해당 토큰으로는 재발급/사용 불가

🔁 리프레시 시 동작 방식
	•	refreshToken() 내부에서 active == true 여부 확인
	•	false인 경우 → “로그아웃된 사용자입니다” 같은 에러 발생
	•	만료된 경우에도 active = false로 갱신 후 예외 처리
	
	----아직 테스트 전입니다---
	