### PR TITLE
공식 게시물 (Explore 게시물) 관련 백앤드 API 개발

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     depends_on:
       - backend
     ports:
-      - "80:80"   # ✅ 여기서 직접 80포트 연결
+      - "80:80"
     networks:
       - web
 

--- a/spring/build.gradle
+++ b/spring/build.gradle
@@ -37,6 +37,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework:spring-tx'
 	implementation 'io.github.cdimascio:java-dotenv:5.2.2'
+	implementation 'software.amazon.awssdk:s3:2.21.10'
+	implementation 'software.amazon.awssdk:auth:2.21.10'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/spring/src/main/java/com/roadit/roaditbackend/config/S3Config.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/config/S3Config.java
@@ -1,0 +1,34 @@
+package com.roadit.roaditbackend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)
+                        )
+                )
+                .build();
+    }
+}

--- a/spring/src/main/java/com/roadit/roaditbackend/config/SecurityConfig.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/config/SecurityConfig.java
@@ -1,21 +1,21 @@
 package com.roadit.roaditbackend.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-
+import org.springframework.http.HttpMethod;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -24,6 +24,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .cors(Customizer.withDefaults())
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(
@@ -31,6 +32,7 @@ public class SecurityConfig {
                                 "/api/login/**",
                                 "/api/auth/**"
                         ).permitAll()
+                        .requestMatchers(HttpMethod.PATCH, "/api/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .formLogin(form -> form.disable())

--- a/spring/src/main/java/com/roadit/roaditbackend/config/WebConfig.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.roadit.roaditbackend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost","http://localhost:3000", "http://localhost:5173", "http://localhost:80")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}

--- a/spring/src/main/java/com/roadit/roaditbackend/controller/ExplorePostAdminController.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/controller/ExplorePostAdminController.java
@@ -1,0 +1,52 @@
+package com.roadit.roaditbackend.controller;
+
+import com.roadit.roaditbackend.dto.*;
+import com.roadit.roaditbackend.service.ExplorePostService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin/explore")
+@RequiredArgsConstructor
+public class ExplorePostAdminController {
+
+    private final ExplorePostService explorePostService;
+
+    // 게시물 등록
+    @PostMapping
+    public ResponseEntity<ApiResponse<ExplorePostCreateResponse>> create(@RequestBody @Valid ExplorePostRequest request) {
+        Long postId = explorePostService.createExplorePost(request);
+
+        ExplorePostCreateResponse response = ExplorePostCreateResponse.builder()
+                .message("Explore 게시물이 등록되었습니다.")
+                .postId(postId)
+                .build();
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // 게시물 수정
+    @PatchMapping("/{id}")
+    public ResponseEntity<ApiResponse<CommonMessageResponse>> patch(
+            @PathVariable Long id,
+            @RequestBody ExplorePostPatchRequest request) {
+
+        explorePostService.patchExplorePost(id, request);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(new CommonMessageResponse("Explore 게시물이 일부 수정되었습니다."))
+        );
+    }
+
+    // 게시물 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<CommonMessageResponse>> delete(@PathVariable Long id) {
+        explorePostService.deleteExplorePost(id);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(new CommonMessageResponse("Explore 게시물이 삭제되었습니다."))
+        );
+    }
+}

--- a/spring/src/main/java/com/roadit/roaditbackend/controller/ExplorePostController.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/controller/ExplorePostController.java
@@ -1,0 +1,32 @@
+package com.roadit.roaditbackend.controller;
+
+import com.roadit.roaditbackend.dto.ApiResponse;
+import com.roadit.roaditbackend.dto.ExplorePostResponse;
+import com.roadit.roaditbackend.service.ExplorePostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/explore")
+@RequiredArgsConstructor
+public class ExplorePostController {
+
+    private final ExplorePostService explorePostService;
+
+    // 전체 게시물 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<ExplorePostResponse>>> getAll() {
+        List<ExplorePostResponse> posts = explorePostService.getAllExplorePosts();
+        return ResponseEntity.ok(ApiResponse.success(posts));
+    }
+
+    // 게시물 상세 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<ExplorePostResponse>> getById(@PathVariable Long id) {
+        ExplorePostResponse post = explorePostService.getExplorePost(id);
+        return ResponseEntity.ok(ApiResponse.success(post));
+    }
+}

--- a/spring/src/main/java/com/roadit/roaditbackend/controller/ImageUploadController.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/controller/ImageUploadController.java
@@ -1,0 +1,32 @@
+package com.roadit.roaditbackend.controller;
+
+import com.roadit.roaditbackend.dto.ApiResponse;
+import com.roadit.roaditbackend.service.S3UploaderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/images")
+public class ImageUploadController {
+
+    private final S3UploaderService s3UploaderService;
+
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<String>> uploadImage(
+            @RequestPart("file") MultipartFile file,
+            @RequestParam(defaultValue = "images") String dir
+    ) {
+        try {
+            String url = s3UploaderService.upload(file, dir);
+            return ResponseEntity.ok(ApiResponse.success(url));
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().body(
+                    ApiResponse.error("파일 업로드 실패: " + e.getMessage(), "UploadError")
+            );
+        }
+    }
+}

--- a/spring/src/main/java/com/roadit/roaditbackend/dto/CommonMessageResponse.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/dto/CommonMessageResponse.java
@@ -1,0 +1,10 @@
+package com.roadit.roaditbackend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommonMessageResponse {
+    private String message;
+}

--- a/spring/src/main/java/com/roadit/roaditbackend/dto/ExplorePostCreateResponse.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/dto/ExplorePostCreateResponse.java
@@ -1,0 +1,11 @@
+package com.roadit.roaditbackend.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExplorePostCreateResponse {
+    private String message;
+    private Long postId;
+}

--- a/spring/src/main/java/com/roadit/roaditbackend/dto/ExplorePostPatchRequest.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/dto/ExplorePostPatchRequest.java
@@ -1,0 +1,28 @@
+package com.roadit.roaditbackend.dto;
+
+import com.roadit.roaditbackend.enums.LanguageType;
+import com.roadit.roaditbackend.enums.PostStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import java.util.List;
+
+
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExplorePostPatchRequest {
+    private String title;
+    private String content;
+    private LanguageType language;
+    private String tag;
+    private PostStatus status;
+    private List<String> imageUrls;
+}

--- a/spring/src/main/java/com/roadit/roaditbackend/dto/ExplorePostRequest.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/dto/ExplorePostRequest.java
@@ -1,0 +1,42 @@
+package com.roadit.roaditbackend.dto;
+
+import com.roadit.roaditbackend.enums.LanguageType;
+import com.roadit.roaditbackend.enums.PostStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExplorePostRequest {
+
+    @NotNull
+    private Long editorId;
+
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String content;
+
+    @NotNull
+    private LanguageType language;
+
+    @NotBlank
+    private String tag;
+
+    @NotNull
+    private PostStatus status;
+
+    @NotNull
+    private List<String> imageUrls;
+}

--- a/spring/src/main/java/com/roadit/roaditbackend/dto/ExplorePostResponse.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/dto/ExplorePostResponse.java
@@ -1,0 +1,27 @@
+package com.roadit.roaditbackend.dto;
+
+import com.roadit.roaditbackend.enums.LanguageType;
+import com.roadit.roaditbackend.enums.PostStatus;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExplorePostResponse {
+
+    private Long id;
+    private Long editorId;
+    private String title;
+    private String content;
+    private LanguageType language;
+    private String tag;
+    private PostStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private List<String> imageUrls;
+}

--- a/spring/src/main/java/com/roadit/roaditbackend/entity/ExplorePost.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/entity/ExplorePost.java
@@ -1,0 +1,53 @@
+package com.roadit.roaditbackend.entity;
+
+import com.roadit.roaditbackend.enums.LanguageType;
+import com.roadit.roaditbackend.enums.PostStatus;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "explore_posts")
+public class ExplorePost {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long editorId;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private LanguageType language;
+
+    @Column(nullable = false)
+    private String tag;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PostStatus status;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_id", referencedColumnName = "id")
+    private List<Images> images = new ArrayList<>();
+
+}

--- a/spring/src/main/java/com/roadit/roaditbackend/entity/Images.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/entity/Images.java
@@ -1,0 +1,39 @@
+package com.roadit.roaditbackend.entity;
+
+import com.roadit.roaditbackend.enums.TargetType;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "images")
+public class Images {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "target_type", nullable = false)
+    private TargetType targetType;
+
+    @Column(name = "image_url", nullable = false)
+    private String imageUrl;
+
+    @Column(nullable = false)
+    private Integer status;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    // Getter/Setter 생략 or Lombok 사용 가능
+}

--- a/spring/src/main/java/com/roadit/roaditbackend/enums/LanguageType.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/enums/LanguageType.java
@@ -1,0 +1,6 @@
+package com.roadit.roaditbackend.enums;
+
+public enum LanguageType {
+    KOR,
+    ENG
+}

--- a/spring/src/main/java/com/roadit/roaditbackend/enums/PostStatus.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/enums/PostStatus.java
@@ -1,0 +1,7 @@
+package com.roadit.roaditbackend.enums;
+
+public enum PostStatus {
+    ACTIVE,     // 게시 중
+    INACTIVE,   // 비활성화
+    DELETED     // 삭제됨
+}

--- a/spring/src/main/java/com/roadit/roaditbackend/enums/TargetType.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/enums/TargetType.java
@@ -1,0 +1,5 @@
+package com.roadit.roaditbackend.enums;
+
+public enum TargetType {
+    EXPLORE_POST
+}

--- a/spring/src/main/java/com/roadit/roaditbackend/exception/GlobalExceptionHandler.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/exception/GlobalExceptionHandler.java
@@ -9,9 +9,17 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+
     @ExceptionHandler(DuplicateEmailException.class)
     public ResponseEntity<ApiResponse<?>> handleDuplicateEmail(DuplicateEmailException e) {
         return ResponseEntity
@@ -59,9 +67,21 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<?>> handleAll(Exception ex) {
+        log.error("🚨 처리되지 않은 예외 발생", ex);
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ApiResponse.error("서버 오류가 발생했습니다.", "InternalServerError"));
     }
-
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<?>> handleUnreadable(HttpMessageNotReadableException ex) {
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.error("요청 본문이 잘못되었습니다.", "HttpMessageNotReadable"));
+    }
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ApiResponse<?>> handleDataIntegrityViolation(DataIntegrityViolationException ex) {
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.error("필수 입력값이 누락되었거나 잘못된 형식입니다.", "DataIntegrityViolation"));
+    }
 }

--- a/spring/src/main/java/com/roadit/roaditbackend/repository/ExplorePostRepository.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/repository/ExplorePostRepository.java
@@ -1,0 +1,11 @@
+package com.roadit.roaditbackend.repository;
+
+import com.roadit.roaditbackend.entity.ExplorePost;
+import com.roadit.roaditbackend.enums.PostStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ExplorePostRepository extends JpaRepository<ExplorePost, Long> {
+    List<ExplorePost> findByStatus(PostStatus status);
+}

--- a/spring/src/main/java/com/roadit/roaditbackend/repository/ImagesRepository.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/repository/ImagesRepository.java
@@ -1,0 +1,13 @@
+package com.roadit.roaditbackend.repository;
+
+import com.roadit.roaditbackend.entity.Images;
+import com.roadit.roaditbackend.enums.TargetType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ImagesRepository extends JpaRepository<Images, Long> {
+    List<Images> findByTargetIdAndTargetType(Long targetId, TargetType targetType);
+    List<Images> findByTargetIdInAndTargetType(List<Long> targetIds, TargetType targetType);
+    void deleteAllByTargetIdAndTargetType(Long targetId, TargetType targetType);
+}

--- a/spring/src/main/java/com/roadit/roaditbackend/service/ExplorePostService.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/service/ExplorePostService.java
@@ -1,0 +1,171 @@
+package com.roadit.roaditbackend.service;
+
+import com.roadit.roaditbackend.dto.ExplorePostRequest;
+import com.roadit.roaditbackend.dto.ExplorePostResponse;
+import com.roadit.roaditbackend.dto.ExplorePostPatchRequest;
+import com.roadit.roaditbackend.entity.ExplorePost;
+import com.roadit.roaditbackend.entity.Images;
+import com.roadit.roaditbackend.enums.TargetType;
+import com.roadit.roaditbackend.repository.ExplorePostRepository;
+import com.roadit.roaditbackend.repository.ImagesRepository;
+import com.roadit.roaditbackend.enums.PostStatus;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.util.Map;
+import java.util.Collections;
+
+
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ExplorePostService {
+
+    private final ExplorePostRepository explorePostRepository;
+    private final ImagesRepository imagesRepository;
+
+    @Transactional
+    public Long createExplorePost(ExplorePostRequest request) {
+        LocalDateTime now = LocalDateTime.now();
+
+        ExplorePost post = new ExplorePost();
+        post.setEditorId(request.getEditorId());
+        post.setTitle(request.getTitle());
+        post.setContent(request.getContent());
+        post.setLanguage(request.getLanguage());
+        post.setTag(request.getTag());
+        post.setStatus(request.getStatus());
+        post.setCreatedAt(now);
+        post.setUpdatedAt(now);
+
+        ExplorePost saved = explorePostRepository.save(post);
+
+        List<Images> images = request.getImageUrls().stream()
+                .map(url -> {
+                    Images image = new Images();
+                    image.setTargetId(saved.getId());
+                    image.setTargetType(TargetType.EXPLORE_POST);
+                    image.setImageUrl(url);
+                    image.setStatus(1); // 기본 1 = 활성
+                    image.setCreatedAt(now);
+                    image.setUpdatedAt(now);
+                    return image;
+                }).collect(Collectors.toList());
+
+        imagesRepository.saveAll(images);
+
+        return saved.getId();
+    }
+
+    @Transactional
+    public ExplorePostResponse getExplorePost(Long id) {
+        ExplorePost post = explorePostRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시물입니다."));
+
+        List<String> imageUrls = imagesRepository
+                .findByTargetIdAndTargetType(id, TargetType.EXPLORE_POST)
+                .stream()
+                .map(Images::getImageUrl)
+                .collect(Collectors.toList());
+
+        return ExplorePostResponse.builder()
+                .id(post.getId())
+                .editorId(post.getEditorId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .language(post.getLanguage())
+                .tag(post.getTag())
+                .status(post.getStatus())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .imageUrls(imageUrls)
+                .build();
+    }
+
+    @Transactional
+    public List<ExplorePostResponse> getAllExplorePosts() {
+        List<ExplorePost> posts = explorePostRepository.findByStatus(PostStatus.ACTIVE);
+
+        List<Long> postIds = posts.stream()
+                .map(ExplorePost::getId)
+                .collect(Collectors.toList());
+
+        List<Images> allImages = imagesRepository.findByTargetIdInAndTargetType(postIds, TargetType.EXPLORE_POST);
+
+        Map<Long, List<String>> imageMap = allImages.stream()
+                .collect(Collectors.groupingBy(
+                        Images::getTargetId,
+                        Collectors.mapping(Images::getImageUrl, Collectors.toList())
+                ));
+
+        return posts.stream()
+                .map(post -> ExplorePostResponse.builder()
+                        .id(post.getId())
+                        .editorId(post.getEditorId())
+                        .title(post.getTitle())
+                        .content(post.getContent())
+                        .language(post.getLanguage())
+                        .tag(post.getTag())
+                        .status(post.getStatus())
+                        .createdAt(post.getCreatedAt())
+                        .updatedAt(post.getUpdatedAt())
+                        .imageUrls(imageMap.getOrDefault(post.getId(), Collections.emptyList()))
+                        .build()
+                ).collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void patchExplorePost(Long id, ExplorePostPatchRequest request) {
+        ExplorePost post = explorePostRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시물입니다."));
+
+        if (request.getTitle() != null) {
+            post.setTitle(request.getTitle());
+        }
+        if (request.getContent() != null) {
+            post.setContent(request.getContent());
+        }
+        if (request.getLanguage() != null) {
+            post.setLanguage(request.getLanguage());
+        }
+        if (request.getTag() != null) {
+            post.setTag(request.getTag());
+        }
+        if (request.getStatus() != null) {
+            post.setStatus(request.getStatus());
+        }
+        post.setUpdatedAt(LocalDateTime.now());
+        if (request.getImageUrls() != null && !request.getImageUrls().isEmpty()) {
+            imagesRepository.deleteAllByTargetIdAndTargetType(id, TargetType.EXPLORE_POST);
+
+            List<Images> newImages = request.getImageUrls().stream()
+                    .map(url -> {
+                        Images img = new Images();
+                        img.setTargetId(id);
+                        img.setTargetType(TargetType.EXPLORE_POST);
+                        img.setImageUrl(url);
+                        img.setStatus(1);
+                        img.setCreatedAt(LocalDateTime.now());
+                        img.setUpdatedAt(LocalDateTime.now());
+                        return img;
+                    }).collect(Collectors.toList());
+
+            imagesRepository.saveAll(newImages);
+        }
+    }
+
+
+
+
+    @Transactional
+    public void deleteExplorePost(Long id) {
+        ExplorePost post = explorePostRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시물입니다."));
+        post.setStatus(com.roadit.roaditbackend.enums.PostStatus.DELETED);
+        post.setUpdatedAt(LocalDateTime.now());
+    }
+}

--- a/spring/src/main/java/com/roadit/roaditbackend/service/S3UploaderService.java
+++ b/spring/src/main/java/com/roadit/roaditbackend/service/S3UploaderService.java
@@ -1,0 +1,52 @@
+package com.roadit.roaditbackend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3UploaderService {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region; // ex) ap-northeast-2
+
+    public String upload(MultipartFile file, String dirName) throws IOException {
+        String originalFilename = file.getOriginalFilename();
+        String extension = originalFilename != null && originalFilename.contains(".")
+                ? originalFilename.substring(originalFilename.lastIndexOf("."))
+                : "";
+
+        String fileName = dirName + "/" +
+                LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss")) +
+                "_" + UUID.randomUUID() + extension;
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(fileName)
+                .contentType(file.getContentType())
+                .build();
+
+        s3Client.putObject(putObjectRequest, RequestBody.fromBytes(file.getBytes()));
+
+        return "https://" + bucket + ".s3." + region + ".amazonaws.com/" +
+                URLEncoder.encode(fileName, StandardCharsets.UTF_8);
+    }
+}

--- a/spring/src/main/resources/application.yml
+++ b/spring/src/main/resources/application.yml
@@ -74,6 +74,7 @@ logging:
   level:
     root: info
     org.springframework.web: DEBUG
+    org.springframework.boot: DEBUG
     org.springframework.validation: DEBUG
     org.hibernate.SQL: DEBUG
     org.hibernate.type: trace

--- a/spring/src/main/resources/application.yml
+++ b/spring/src/main/resources/application.yml
@@ -76,6 +76,7 @@ logging:
     org.springframework.web: DEBUG
     org.springframework.boot: DEBUG
     org.springframework.validation: DEBUG
+    org.springframework.boot.autoconfigure: warn
     org.hibernate.SQL: DEBUG
     org.hibernate.type: trace
 
@@ -84,3 +85,14 @@ jwt:
   access-token-expiration: 900000      # 15분 유효
   refresh-token-expiration: 604800000  # 7일 유효
 
+cloud:
+  aws:
+    s3:
+      bucket: ${S3_BUCKET_NAME}
+    credentials:
+      access-key: ${S3_ACCESS_KEY}
+      secret-key: ${S3_SECRET_KEY}
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false


### PR DESCRIPTION
<개발 내용> - 전부 테스트 완료
- Admin ExplorePost API
  - 게시물 등록 기능
  - 게시물 수정 기능
  - 게시물 삭제 기능
- User ExplorePost API
  - 게시물 목록 조회 기능
  - 게시물 상세 조회 기능
- Image Upload API
  - AWS S3 Bucket에 이미지 업로드 기능 (업로드된 이미지의 URL 반환) 

[Admin ExplorePost API](https://github.com/ejiyoon37/roadit/wiki/Admin-ExplorePost-API)
[User ExplorePost API](https://github.com/ejiyoon37/roadit/wiki/User-ExplorePost-API)
[Image Upload API](https://github.com/ejiyoon37/roadit/wiki/Image-Upload-API)

API 문서 참조.


<이후 개발 방향>
 1. 가보고 싶어요 기능.
 2. 지금 올리는 API는 admin 관련 인증이나 token을 받지 않기에, 호출 API가 유출되면 악용 소지가 있음. 장기적으로 봤을 때, Request에서 권한 인증을 받아야 할 것으로 보임.